### PR TITLE
increase timeout of ssh_connect(), so that a NAS has time to spinup disk

### DIFF
--- a/src/SFTPSession.cpp
+++ b/src/SFTPSession.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <kodi/General.h>
 
-#define SFTP_TIMEOUT 5
+#define SFTP_TIMEOUT 10
 #if !defined(S_ISREG)
 #define S_ISREG(m) ((m & _S_IFREG) != 0)
 #endif


### PR DESCRIPTION
fixes https://trac.kodi.tv/ticket/17711

If you see my problem of slow NAS spinup, but don't agree with my (bit lazy) fix, then let's discuss a better solution. Is it worth to add a UI editable config option for SFTP_TIMEOUT? Or to measure and store the typical time until ready of each sftp share?
