### PR TITLE
[depends] fix windows libssh build failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,12 @@ environment:
       CONFIG: Release
     - GENERATOR: "Visual Studio 14 Win64"
       CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
+    - GENERATOR: "Visual Studio 14 ARM"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
 
 build_script:
   - cd ..
@@ -23,5 +29,5 @@ build_script:
   - cd build
   - mkdir -p definition\%app_id%
   - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
-  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake -T host=x64 -G "%GENERATOR%" %WINSTORE% -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
   - cmake --build . --config %CONFIG% --target %app_id%

--- a/depends/common/libssh/01-removelegacy.patch
+++ b/depends/common/libssh/01-removelegacy.patch
@@ -1,5 +1,5 @@
---- a/src/CMakeLists.txt	2011-06-16 19:04:44.000000000 +0200
-+++ b/src/CMakeLists.txt	2011-06-16 19:03:40.000000000 +0200
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
 @@ -123,7 +123,6 @@
    init.c
    kex.c

--- a/depends/common/libssh/03-md5.patch
+++ b/depends/common/libssh/03-md5.patch
@@ -1,6 +1,5 @@
-diff -ruN a/include/libssh/wrapper.h b/include/libssh/wrapper.h
---- a/include/libssh/wrapper.h	2011-05-31 10:29:52.000000000 -0400
-+++ b/include/libssh/wrapper.h	2012-07-26 00:21:16.021511996 -0400
+--- a/include/libssh/wrapper.h
++++ b/include/libssh/wrapper.h
 @@ -52,7 +52,7 @@
  };
  
@@ -10,9 +9,8 @@ diff -ruN a/include/libssh/wrapper.h b/include/libssh/wrapper.h
  void md5_update(MD5CTX c, const void *data, unsigned long len);
  void md5_final(unsigned char *md,MD5CTX c);
  
-diff -ruN a/src/dh.c b/src/dh.c
---- a/src/dh.c	2011-05-31 10:29:52.000000000 -0400
-+++ b/src/dh.c	2012-07-26 00:19:52.961512049 -0400
+--- a/src/dh.c
++++ b/src/dh.c
 @@ -918,7 +918,7 @@
      return SSH_ERROR;
    }
@@ -31,9 +29,8 @@ diff -ruN a/src/dh.c b/src/dh.c
              if (ctx == NULL) {
                  free(h);
                  rc = -1;
-diff -ruN a/src/kex.c b/src/kex.c
---- a/src/kex1.c	2011-05-31 10:29:52.000000000 -0400
-+++ b/src/kex1.c	2012-07-26 00:20:37.671512021 -0400
+--- a/src/kex1.c
++++ b/src/kex1.c
 @@ -78,7 +78,7 @@
      ssh_string hostn) {
    MD5CTX md5 = NULL;
@@ -43,9 +40,8 @@ diff -ruN a/src/kex.c b/src/kex.c
    if (md5 == NULL) {
      return -1;
    }
-diff -ruN a/src/libcrypto.c b/src/libcrypto.c
---- a/src/libcrypto.c	2011-05-31 10:29:52.000000000 -0400
-+++ b/src/libcrypto.c	2012-07-26 00:20:07.061512022 -0400
+--- a/src/libcrypto.c
++++ b/src/libcrypto.c
 @@ -234,7 +234,7 @@
    SHA512(digest, len, hash);
  }
@@ -55,9 +51,8 @@ diff -ruN a/src/libcrypto.c b/src/libcrypto.c
    MD5CTX c = malloc(sizeof(*c));
    if (c == NULL) {
      return NULL;
-diff -ruN a/src/libgcrypt.c b/src/libgcrypt.c
---- a/src/libgcrypt.c	2011-05-31 10:29:52.000000000 -0400
-+++ b/src/libgcrypt.c	2012-07-26 00:20:19.401512036 -0400
+--- a/src/libgcrypt.c
++++ b/src/libgcrypt.c
 @@ -132,7 +132,7 @@
    gcry_md_hash_buffer(GCRY_MD_SHA512, hash, digest, len);
  }

--- a/depends/common/libssh/04-stack-protector.patch
+++ b/depends/common/libssh/04-stack-protector.patch
@@ -1,5 +1,5 @@
---- libssh-0.5.0/cmake/Modules/DefineCompilerFlags.cmake.old	2013-11-22 19:18:48.782909698 +0100
-+++ libssh-0.5.0/cmake/Modules/DefineCompilerFlags.cmake	2013-11-22 19:19:26.190911487 +0100
+--- a/cmake/Modules/DefineCompilerFlags.cmake
++++ b/cmake/Modules/DefineCompilerFlags.cmake
 @@ -21,9 +21,9 @@
              set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
          endif (WITH_FPIC)

--- a/depends/common/libssh/06-windowsstore.patch
+++ b/depends/common/libssh/06-windowsstore.patch
@@ -60,15 +60,18 @@
          r->v[i] ^= mask & (x->v[i] ^ r->v[i]);
 --- a/src/misc.c
 +++ b/src/misc.c
-@@ -49,6 +49,7 @@
+@@ -49,6 +49,10 @@
  #include <time.h>
  
  #ifdef _WIN32
++#if !defined(WIN32_LEAN_AND_MEAN)
++#define WIN32_LEAN_AND_MEAN
++#endif
 +#include <windows.h>
  
  #ifndef _WIN32_IE
  # define _WIN32_IE 0x0501 // SHGetSpecialFolderPath
-@@ -98,6 +99,7 @@
+@@ -98,6 +102,7 @@
  
  #ifdef _WIN32
  char *ssh_get_user_home_dir(void) {
@@ -76,7 +79,7 @@
    char tmp[MAX_PATH] = {0};
    char *szPath = NULL;
  
-@@ -110,6 +112,7 @@
+@@ -110,6 +115,7 @@
      strcpy(szPath, tmp);
      return szPath;
    }
@@ -84,7 +87,7 @@
  
    return NULL;
  }
-@@ -140,6 +143,7 @@
+@@ -140,6 +146,7 @@
  }
  
  char *ssh_get_local_username(void) {
@@ -92,7 +95,7 @@
      DWORD size = 0;
      char *user;
  
-@@ -154,6 +158,7 @@
+@@ -154,6 +161,7 @@
      if (GetUserName(user, &size)) {
          return user;
      }


### PR DESCRIPTION
including <windows.h> without defining `WIN32_LEAN_AND_MEAN`, pulls in Winsock (1). This conflicts with Winsock2, which is used by libssh.