### PR TITLE
fixed: Faulty SFTP protocol name causing all kinds of problems like v…

### DIFF
--- a/vfs.sftp/addon.xml.in
+++ b/vfs.sftp/addon.xml.in
@@ -7,7 +7,7 @@
   <requires>@ADDON_DEPENDS@</requires>
   <extension
     point="kodi.vfs"
-    protocols="sftp|ssh"
+    protocols="sftp"
     files="true"
     directories="true"
     supportDialog="true"


### PR DESCRIPTION
…ideo scanner failure (fixes #15542)

The actual problem here is that sources get added with protocol name "sftp|ssh://" but the items returned by the sftp vfs have "sftp://". So when eg. the scraper looks for items with "sftp://" it's unable to find the parent path for them.

Also note that "sftp|ssh://" looks weird and is probably also confusing for users.