### PR TITLE
Add SFTP write support for Matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This is a [Kodi](https://kodi.tv) VFS addon to support SFTP file systems.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/vfs.sftp/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/vfs.sftp/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.vfs.sftp?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=54&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/vfs.sftp/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvfs.sftp/branches/)
+[![Build and run tests](https://github.com/xbmc/vfs.sftp/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/vfs.sftp/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.vfs.sftp?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=54&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/vfs.sftp/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvfs.sftp/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/vfs.sftp?svg=true)](https://ci.appveyor.com/project/xbmc/vfs-sftp) -->
 
 ## Build instructions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/src/SFTPFile.cpp
+++ b/src/SFTPFile.cpp
@@ -11,6 +11,7 @@
 #include <kodi/addon-instance/VFS.h>
 #include <map>
 #include <sstream>
+#include <fcntl.h>
 
 class ATTRIBUTE_HIDDEN CSFTPFile : public kodi::addon::CInstanceVFS
 {
@@ -26,22 +27,7 @@ public:
 
   kodi::addon::VFSFileHandle Open(const kodi::addon::VFSUrl& url) override
   {
-    SFTPContext* result = new SFTPContext;
-
-    result->session = CSFTPSessionManager::Get().CreateSession(url);
-
-    if (result->session)
-    {
-      result->file = url.GetFilename().c_str();
-      result->sftp_handle = result->session->CreateFileHande(result->file);
-      if (result->sftp_handle)
-        return result;
-    }
-    else
-      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to allocate session");
-
-    delete result;
-    return nullptr;
+    return OpenInternal(url, O_RDONLY);
   }
 
   ssize_t Read(kodi::addon::VFSFileHandle context, uint8_t* buffer, size_t uiBufSize) override
@@ -58,6 +44,24 @@ public:
     }
     else
       kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Can't read without a handle");
+
+    return -1;
+  }
+
+  ssize_t Write(kodi::addon::VFSFileHandle context, const uint8_t* buffer, size_t uiBufSize) override
+  {
+    SFTPContext* ctx = static_cast<SFTPContext*>(context);
+    if (ctx && ctx->session && ctx->sftp_handle)
+    {
+      int writeBytes = ctx->session->Write(ctx->sftp_handle, buffer, uiBufSize);
+
+      if (writeBytes >= 0)
+        return writeBytes;
+      else
+        kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to write %i");
+    }
+    else
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Can't write without a handle");
 
     return -1;
   }
@@ -172,6 +176,106 @@ public:
         << url.GetHostname() << ":" << (url.GetPort() ? url.GetPort() : 22) << "/";
 
     return session->GetDirectory(str.str(), url.GetFilename(), items);
+  }
+
+  bool Delete(const kodi::addon::VFSUrl& url) override
+  {
+    CSFTPSessionPtr session = CSFTPSessionManager::Get().CreateSession(url);
+    if (session)
+      return session->DeleteFile(url.GetFilename());
+    else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to create session to delete file '%s'",
+                url.GetFilename().c_str());
+      return false;
+    }
+  }
+
+  bool RemoveDirectory(const kodi::addon::VFSUrl& url) override
+  {
+    CSFTPSessionPtr session = CSFTPSessionManager::Get().CreateSession(url);
+    if (session)
+      return session->DeleteDirectory(url.GetFilename());
+    else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to create session to delete folder '%s'",
+                url.GetFilename().c_str());
+      return false;
+    }
+  }
+
+  bool CreateDirectory(const kodi::addon::VFSUrl& url) override
+  {
+    CSFTPSessionPtr session = CSFTPSessionManager::Get().CreateSession(url);
+    if (session)
+      return session->CreateDirectory(url.GetFilename());
+    else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to create session to create folder '%s'",
+                url.GetFilename().c_str());
+      return false;
+    }
+  }
+
+  bool Rename(const kodi::addon::VFSUrl& url_from, const kodi::addon::VFSUrl& url_to) override
+  {
+    CSFTPSessionPtr session = CSFTPSessionManager::Get().CreateSession(url_from);
+    if (session)
+      return session->RenameFile(url_from.GetFilename(), url_to.GetFilename());
+    else
+    {
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to create session to rename file '%s'",
+                url_from.GetFilename().c_str());
+      return false;
+    }
+  }
+
+  bool ContainsFiles(const kodi::addon::VFSUrl& url,
+                    std::vector<kodi::vfs::CDirEntry>& items,
+                    std::string &rootPath) override
+  {
+    return DirectoryExists(url) && !items.empty();
+  }
+
+  kodi::addon::VFSFileHandle OpenForWrite(const kodi::addon::VFSUrl& url, bool overWrite) override
+  {
+    if (overWrite)
+      return OpenInternal(url, O_RDWR | O_CREAT | O_TRUNC);
+    else
+      return OpenInternal(url, O_RDWR | O_CREAT);
+  }
+
+  int Truncate(kodi::addon::VFSFileHandle context, int64_t size) override
+  {
+    kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Truncate is not implemented");
+    return -1;
+  }
+
+  bool IoControlGetCacheStatus (kodi::addon::VFSFileHandle context, kodi::vfs::CacheStatus &status) override { return false; }
+
+  bool IoControlSetCacheRate (kodi::addon::VFSFileHandle context, unsigned int rate) override { return false; }
+
+  bool IoControlSetRetry (kodi::addon::VFSFileHandle context, bool retry) override { return false; }
+
+private:
+  kodi::addon::VFSFileHandle OpenInternal(const kodi::addon::VFSUrl& url, mode_t mode)
+  {
+    SFTPContext* result = new SFTPContext;
+
+    result->session = CSFTPSessionManager::Get().CreateSession(url);
+
+    if (result->session)
+    {
+      result->file = url.GetFilename().c_str();
+      result->sftp_handle = result->session->CreateFileHande(result->file, mode);
+      if (result->sftp_handle)
+        return result;
+    }
+    else
+      kodi::Log(ADDON_LOG_ERROR, "SFTPFile: Failed to allocate session");
+
+    delete result;
+    return nullptr;
   }
 };
 

--- a/src/SFTPSession.cpp
+++ b/src/SFTPSession.cpp
@@ -23,6 +23,15 @@
 #ifndef S_ISLNK
 #define S_ISLNK(m) ((((m)) & 0170000) == (0120000))
 #endif
+#ifndef S_IWUSR
+#define S_IWUSR 00200
+#endif
+#ifndef S_IRUSR
+#define S_IRUSR 00400
+#endif
+#ifndef S_IRWXU
+#define S_IRWXU 00700
+#endif
 
 
 static std::string CorrectPath(const std::string& path)
@@ -90,13 +99,13 @@ CSFTPSession::~CSFTPSession()
   Disconnect();
 }
 
-sftp_file CSFTPSession::CreateFileHande(const std::string& file)
+sftp_file CSFTPSession::CreateFileHande(const std::string& file, mode_t mode)
 {
   if (m_connected)
   {
     std::unique_lock<std::recursive_mutex> lock(m_lock);
     m_LastActive = std::chrono::high_resolution_clock::now();
-    sftp_file handle = sftp_open(m_sftp_session, CorrectPath(file).c_str(), O_RDONLY, 0);
+    sftp_file handle = sftp_open(m_sftp_session, CorrectPath(file).c_str(), mode, S_IRUSR | S_IWUSR);
     if (handle)
     {
       sftp_file_set_blocking(handle);
@@ -291,6 +300,14 @@ int CSFTPSession::Read(sftp_file handle, void* buffer, size_t length)
   return result;
 }
 
+int CSFTPSession::Write(sftp_file handle, const void* buffer, size_t length)
+{
+  std::unique_lock<std::recursive_mutex> lock(m_lock);
+  m_LastActive = std::chrono::high_resolution_clock::now();
+  int result = sftp_write(handle, buffer, length);
+  return result;
+}
+
 int64_t CSFTPSession::GetPosition(sftp_file handle)
 {
   std::unique_lock<std::recursive_mutex> lock(m_lock);
@@ -305,6 +322,38 @@ bool CSFTPSession::IsIdle()
   return static_cast<int>(
              std::chrono::duration_cast<std::chrono::milliseconds>(now - m_LastActive).count()) >
          90000;
+}
+
+bool CSFTPSession::DeleteFile(const std::string& path)
+{
+  std::unique_lock<std::recursive_mutex> lock(m_lock);
+  m_LastActive = std::chrono::high_resolution_clock::now();
+  int result = sftp_unlink(m_sftp_session, CorrectPath(path).c_str());
+  return result == 0 ? true : false;
+}
+
+bool CSFTPSession::DeleteDirectory(const std::string& path)
+{
+  std::unique_lock<std::recursive_mutex> lock(m_lock);
+  m_LastActive = std::chrono::high_resolution_clock::now();
+  int result = sftp_rmdir(m_sftp_session, CorrectPath(path).c_str());
+  return result == 0 ? true : false;
+}
+
+bool CSFTPSession::CreateDirectory(const std::string& path)
+{
+  std::unique_lock<std::recursive_mutex> lock(m_lock);
+  m_LastActive = std::chrono::high_resolution_clock::now();
+  int result = sftp_mkdir(m_sftp_session, CorrectPath(path).c_str(), S_IRWXU);
+  return result == 0 ? true : false;
+}
+
+bool CSFTPSession::RenameFile(const std::string& path_from, const std::string& path_to)
+{
+  std::unique_lock<std::recursive_mutex> lock(m_lock);
+  m_LastActive = std::chrono::high_resolution_clock::now();
+  int result = sftp_rename(m_sftp_session, CorrectPath(path_from).c_str(), CorrectPath(path_to).c_str());
+  return result == 0 ? true : false;
 }
 
 bool CSFTPSession::VerifyKnownHost(ssh_session session)

--- a/src/SFTPSession.h
+++ b/src/SFTPSession.h
@@ -23,7 +23,7 @@ public:
   CSFTPSession(const kodi::addon::VFSUrl& url);
   virtual ~CSFTPSession();
 
-  sftp_file CreateFileHande(const std::string& file);
+  sftp_file CreateFileHande(const std::string& file, mode_t mode);
   void CloseFileHandle(sftp_file handle);
   bool GetDirectory(const std::string& base,
                     const std::string& folder,
@@ -33,8 +33,13 @@ public:
   int Stat(const std::string& path, kodi::vfs::FileStatus& buffer);
   int Seek(sftp_file handle, uint64_t position);
   int Read(sftp_file handle, void* buffer, size_t length);
+  int Write(sftp_file handle, const void* buffer, size_t length);
   int64_t GetPosition(sftp_file handle);
   bool IsIdle();
+  bool DeleteFile(const std::string& path);
+  bool DeleteDirectory(const std::string& path);
+  bool CreateDirectory(const std::string& path);
+  bool RenameFile(const std::string& path_from, const std::string& path_to);
 
 private:
   bool VerifyKnownHost(ssh_session session);

--- a/vfs.sftp/addon.xml.in
+++ b/vfs.sftp/addon.xml.in
@@ -16,6 +16,7 @@
     supportPassword="true"
     supportPort="true"
     supportBrowsing="false"
+    supportWrite="true"
     defaultPort="22"
     type="sftp"
     label="20260"

--- a/vfs.sftp/addon.xml.in
+++ b/vfs.sftp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="vfs.sftp"
-  version="2.0.0"
+  version="20.0.0"
   name="SFTP support"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This PR adds SFTP write support for Matrix variant.

Support is added for the follow new capabilities:

mkdir
rmdir
rename
delete file
OpenForWrite
write
I tested those new capabilities and the plugin on Kodi 19.1