### PR TITLE
Add SFTP write support

### DIFF
--- a/src/SFTPSession.h
+++ b/src/SFTPSession.h
@@ -23,7 +23,7 @@ public:
   CSFTPSession(const kodi::addon::VFSUrl& url);
   virtual ~CSFTPSession();
 
-  sftp_file CreateFileHande(const std::string& file);
+  sftp_file CreateFileHande(const std::string& file, mode_t mode);
   void CloseFileHandle(sftp_file handle);
   bool GetDirectory(const std::string& base,
                     const std::string& folder,
@@ -33,8 +33,13 @@ public:
   int Stat(const std::string& path, kodi::vfs::FileStatus& buffer);
   int Seek(sftp_file handle, uint64_t position);
   int Read(sftp_file handle, void* buffer, size_t length);
+  int Write(sftp_file handle, const void* buffer, size_t length);
   int64_t GetPosition(sftp_file handle);
   bool IsIdle();
+  bool DeleteFile(const std::string& path);
+  bool DeleteDirectory(const std::string& path);
+  bool MakeDirectory(const std::string& path);
+  bool RenameFile(const std::string& path_from, const std::string& path_to);
 
 private:
   bool VerifyKnownHost(ssh_session session);

--- a/vfs.sftp/addon.xml.in
+++ b/vfs.sftp/addon.xml.in
@@ -16,6 +16,7 @@
     supportPassword="true"
     supportPort="true"
     supportBrowsing="false"
+    supportWrite="true"
     defaultPort="22"
     type="sftp"
     label="20260"


### PR DESCRIPTION
This PR adds SFTP write support to the vfs.sftp plugin.

Support is added for the follow new capabilities:

- mkdir
- rmdir
- rename
- delete file
- OpenForWrite
- write

I tested those new capabilities and the plugin on Kodi 19.1
This is a follow-up on #80 and #81, to open the PR on the correct branch, sorry about all that confusion

Fixes: #62 