### PR TITLE
Build for ARM instead of ARM64 as ARM64 is not supported in Kodi

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,9 @@ jobs:
           ARCHITECTURE: x64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
-        ARM64-UWP:
+        ARM-UWP:
           GENERATOR: "Visual Studio 17 2022"
-          ARCHITECTURE: ARM64
+          ARCHITECTURE: ARM
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
 


### PR DESCRIPTION
But as Kodi does support ARM on UWP we'll build that instead.